### PR TITLE
Add gmmk/tecware keyboards

### DIFF
--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -28,12 +28,16 @@ CMD_REBOOT = CMD_BASE + 7
 EXPECTED_STATUS = 0xFAFAFAFA
 
 DEVICE_DESC = {
-    (0x0c45, 0x7698): "Womier K66",
-    (0x320F, 0x5013): "Akko 3084 Bt5.0",
-    (0x0c45, 0x766b): "Kemove DK63",
-    (0x05ac, 0x024f): "Keychron K4",
+    # keyboards in bootloader mode:
     (0x0c45, 0x7010): "SN32F268F (bootloader)",
     (0x0c45, 0x7040): "SN32F248B (bootloader)",
+    
+    # keyboards in normal mode:
+    (0x05ac, 0x024f): "Keychron K4",
+    (0x0c45, 0x652f): "Glorious GMMK / Tecware Phantom",
+    (0x0c45, 0x766b): "Kemove DK63",
+    (0x0c45, 0x7698): "Womier K66",
+    (0x320F, 0x5013): "Akko 3084 Bt5.0",
 }
 
 

--- a/src/main/resources/base/devices.ini
+++ b/src/main/resources/base/devices.ini
@@ -2,6 +2,3 @@
 vid = 0x320F
 pid = 0x5013
 
-[Akko 3084 Bootloader]
-vid = 0x0c45
-pid = 0x7010


### PR DESCRIPTION
* Added support for gmmk/tecware keyboard (they have the same vid/pid)
* Sorted the keyboard data 
* Removed "Akko 3084 Bootloader" from ini, otherwise all 268 boards show up as Akko