### PR TITLE
Fixed Default Resolution to not hide offset radio buttons

### DIFF
--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -456,7 +456,7 @@ def excepthook(exc_type, exc_value, exc_tb):
 if __name__ == '__main__':
     appctxt = ApplicationContext()
     window = MainWindow()
-    window.resize(600, 250)
+    window.resize(600, 500)
     window.setWindowTitle("Sonix Keyboard Flasher")
     window.show()
     sys.excepthook = excepthook


### PR DESCRIPTION
This commit makes it so that the 0x200 and 0x00 radio buttons for flashing offset are not hidden by default, by making the Window taller by default, which solves the issue.