### PR TITLE
Add support for SPCGear GK630K

### DIFF
--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -45,6 +45,7 @@ DEVICE_DESC = {
     (0x0c45, 0x5104): "Redragon",
     (0x0C45, 0x8513): "Sharkoon",
     (0x0C45, 0x8508): "SPCGear",
+    (0x3299, 0x4E58): "SPCGear",
     (0x0C45, 0x7903): "Ajazz",
     (0x3434, 0xfe00): "Keychron K1 ANSI",
     (0x3434, 0xfe01): "Keychron K1 ISO",


### PR DESCRIPTION
This PR adds IDs for SPCGear GK630K and possibly GK650K keyboards.