### PR TITLE
Fix macOS build action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
       run: |
         python -m venv venv
         source venv/bin/activate
+        pip install cython
         pip install -r requirements.txt
 
     - name: Build


### PR DESCRIPTION
Install Cython before installing requirements. 