### PR TITLE
Inform about key for GMMK users

### DIFF
--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -254,7 +254,7 @@ class MainWindow(QWidget):
         btn_flash_qmk.clicked.connect(self.on_click_flash_qmk)
 
         lbl_help = QLabel(
-            "After jumploader is installed, hold Backspace while plugging in the keyboard to start in bootloader mode.")
+            "After jumploader is installed, hold Backspace(Enter for GMMK keyboards) while plugging in the keyboard to start in bootloader mode.")
         lbl_help.setWordWrap(True)
 
         btn_reboot_bl_evision = QPushButton("Reboot to Bootloader [eVision]")


### PR DESCRIPTION
For GMMK keyboards the key to get into bootloader mode is ENTER not Backspace as seen in https://github.com/SonixQMK/sonix-keyboard-bootloader/blob/master/src/config.h#L158
Probably a better solution would be to link to the bootloader page somehow.