### PR TITLE
Upgrade hidapi to 0.14.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 altgraph==0.17
 fbs==0.8.6
 future==0.18.2
-hidapi==0.9.0.post2
+hidapi==0.14.0
 macholib==1.14
 pefile==2019.4.18
 PyInstaller==3.4


### PR DESCRIPTION
The 0.9.0.post2 version of hidapi no longer compiles on e.g. Ubuntu 22.04 LTS.  Upgrading to 0.14.0 solves the issue.  I've tested that I can use the flasher on a Svive Triton Full keyboard (that uses SN32F248B).

Without this upgrade, compilation fails like this for me:

```
  × Running setup.py install for hidapi did not run successfully.
  │ exit code: 1
  ╰─> [9 lines of output]
      /home/ceder/.venv/sonix-flasher/lib/python3.10/site-packages/setuptools/installer.py:27: SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
        warnings.warn(
      running install
      /home/ceder/.venv/sonix-flasher/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
        warnings.warn(
      running build
      running build_ext
      building 'hid' extension
      error: unknown file type '.pxd' (from 'chid.pxd')```